### PR TITLE
Set default Boost version to 1.83.0

### DIFF
--- a/.github/workflows/release_linux.yml
+++ b/.github/workflows/release_linux.yml
@@ -29,7 +29,7 @@ jobs:
       CONTAINER_TMP: /opt/
       HOST_TMP: /home/runner/work/_temp/
       DEBIAN_FRONTEND: noninteractive
-      BOOST_VERSION: "1.84.0"
+      BOOST_VERSION: "1.83.0"
 
     container:
       image: ubuntu:22.04

--- a/.github/workflows/reusable-generate-proofs-linux.yml
+++ b/.github/workflows/reusable-generate-proofs-linux.yml
@@ -33,7 +33,7 @@ on:
         type: string
         description: "Version of Boost to install"
         required: false
-        default: '1.84.0'
+        default: '1.83.0'
 
     outputs:
       artifact-name:


### PR DESCRIPTION
MarkusJx/install-boost action should use [this version](https://github.com/MarkusJx/prebuilt-boost/blob/55a846d4888c0ecb4629173a28b75c1bedd74a8d/versions-manifest.json#L1204-L1210) now