### PR TITLE
fix: erase nix-created flags for multithreaded version

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -15,7 +15,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  BOOST_VERSION: "1.80.0"
   CAA_ARTIFACT_NAME: circuits-and-assignments
   TO_ARTIFACT_NAME: transpiler-output
   INTEGRATION_TESTING_TARGETS: |
@@ -126,7 +125,7 @@ jobs:
 
   build-and-generate-proofs:
     name: Build prover, generate proofs for circuits
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, Linux, X64, aws_autoscaling]
     needs:
       - handle-syncwith
       - get-zkllvm-run
@@ -140,6 +139,10 @@ jobs:
       artifact-name: ${{ steps.artifact-name.outputs.merged }}
 
     steps:
+      # https://github.com/actions/checkout/issues/1552
+      - name: Clean up after previous checkout
+        run: chmod +w -R ${GITHUB_WORKSPACE}; rm -rf ${GITHUB_WORKSPACE}/*;
+
       - name: Checkout Proof Producer
         uses: actions/checkout@v4
         with:
@@ -155,9 +158,6 @@ jobs:
             ${{ github.workspace }}/**
             !${{ github.workspace }}/
             !${{ github.workspace }}/**/.git/**
-
-      - uses: cachix/install-nix-action@v27
-      - uses: DeterminateSystems/magic-nix-cache-action@v7
 
       - name: Run checks
         run: nix -L build '.?submodules=1#'
@@ -194,7 +194,7 @@ jobs:
         working-directory: ${{ steps.strings.outputs.artifact-dir }}
         run: |
           extra_args=""
-          if [[ "true" == "false" ]]; then
+          if [[ "true" == "true" ]]; then
             extra_args="--multithreaded "
           fi
           targets_str=$(echo "${{ needs.prepare-targets.outputs.prover-targets }}" | awk '{$1=$1};1' | sed '/^$/d' | tr '\n' ' ' | sed 's/ $//')

--- a/bin/proof-producer/CMakeLists.txt
+++ b/bin/proof-producer/CMakeLists.txt
@@ -63,7 +63,7 @@ function(setup_proof_generator_target)
     target_include_directories(${ARG_TARGET_NAME} PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-        $<$<BOOL:${Boost_FOUND}>:${Boost_INCLUDE_DIRS}>)
+    )
 
     target_link_libraries(${ARG_TARGET_NAME}
         crypto3::all
@@ -79,10 +79,10 @@ endfunction()
 
 # Declare single-threaded target
 set(SINGLE_THREADED_TARGET "${CURRENT_PROJECT_NAME}-single-threaded")
-setup_proof_generator_target(TARGET_NAME ${SINGLE_THREADED_TARGET} crypto3::zk)
+setup_proof_generator_target(TARGET_NAME ${SINGLE_THREADED_TARGET})
 
 # Declare multi-threaded target
-# set(MULTI_THREADED_TARGET "${CURRENT_PROJECT_NAME}-multi-threaded")
-# setup_proof_generator_target(TARGET_NAME ${MULTI_THREADED_TARGET} ADDITIONAL_DEPENDENCIES actor::zk)
+set(MULTI_THREADED_TARGET "${CURRENT_PROJECT_NAME}-multi-threaded")
+setup_proof_generator_target(TARGET_NAME ${MULTI_THREADED_TARGET} ADDITIONAL_DEPENDENCIES actor::zk)
 
 install(TARGETS ${SINGLE_THREADED_TARGET} ${MULTI_THREADED_TARGET} RUNTIME DESTINATION bin)

--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,18 @@
   "nodes": {
     "crypto3": {
       "inputs": {
+        "flake-utils": "flake-utils",
         "nix-3rdparty": "nix-3rdparty",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1720200505,
-        "narHash": "sha256-eKb9e/+E+jZKdoJrsvUhaKqElfio6PMl97W+bSvKq+Q=",
+        "lastModified": 1721325480,
+        "narHash": "sha256-ZyPvRjfeLVswifsbmoUm2LIcrqIaXR4wQmA0XdpEv6g=",
         "ref": "refs/heads/master",
-        "rev": "3bd5b8df2091274abaa28fd86b9e3e89d661b95a",
-        "revCount": 9150,
+        "rev": "45074e0549d46b8fa67a844111c52277134a0272",
+        "revCount": 9160,
         "type": "git",
         "url": "https://github.com/NilFoundation/crypto3"
       },
@@ -59,7 +60,10 @@
     },
     "nix-3rdparty": {
       "inputs": {
-        "flake-utils": "flake-utils",
+        "flake-utils": [
+          "crypto3",
+          "flake-utils"
+        ],
         "nixpkgs": [
           "crypto3",
           "nixpkgs"
@@ -81,11 +85,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1718811006,
-        "narHash": "sha256-0Y8IrGhRmBmT7HHXlxxepg2t8j1X90++qRN3lukGaIk=",
+        "lastModified": 1720535198,
+        "narHash": "sha256-zwVvxrdIzralnSbcpghA92tWu2DV2lwv89xZc8MTrbg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "03d771e513ce90147b65fe922d87d3a0356fc125",
+        "rev": "205fd4226592cc83fd4c0885a3e4c9c400efabb5",
         "type": "github"
       },
       "original": {
@@ -105,11 +109,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718893869,
-        "narHash": "sha256-PbQBaMoT99tr/CpQfPwPuXexOBxsB4Cajasuuc0pjk4=",
+        "lastModified": 1721378514,
+        "narHash": "sha256-3XRkqdZRe26YDBPWFZmpVqyFQeqPmDczx5AaaY3FRTQ=",
         "ref": "refs/heads/master",
-        "rev": "bb57c9ddd8d105cae2a455c1085cb9f1f08c5bed",
-        "revCount": 1444,
+        "rev": "404077b3f00f8c901cfad95c8c6c116eb172b8e2",
+        "revCount": 1460,
         "submodules": true,
         "type": "git",
         "url": "https://github.com/NilFoundation/parallel-crypto3"

--- a/tests/make_proof_for_pairs.sh
+++ b/tests/make_proof_for_pairs.sh
@@ -17,7 +17,7 @@ make_proof_for_pair() {
     if [ "$use_nix" = true ]; then
         proof_generator_binary="nix run ${script_dir}/..?submodules=1#single-threaded --"
         if [ "$use_multithreaded" = true ]; then
-            proof_generator_binary="nix run ${script_dir}/..?submodules=1 --"
+            proof_generator_binary="nix run ${script_dir}/..?submodules=1# --"
         fi
     else
         proof_generator_binary="${script_dir}/../build/bin/proof-generator/proof-generator-single-threaded"


### PR DESCRIPTION
Enable multi-threaded version in cmake, fix parallel-crypto3 bug, use multi-threaded version in CI by default. Check the comment in flake.nix as well