### PR TITLE
Separate preprocessing from proving and verification by adding a parameter --stage to proof producer

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,29 @@ proof-generator --circuit <circuit-file> --assignment <assignment-file> --proof 
     cmake ..
     make -j $(nrpoc)
     ```
+
+# Sample calls to proof-producer
+
+In all the calls you can change the executable name from proof-producer-single-threaded to proof-producer-multi-threaded to run on all the CPUs of your machine.
+
+Generate a proof and verify it:
+```bash
+./build/bin/proof-producer/proof-producer-single-threaded --circuit="circuit.crct" --assignment-table="assignment.tbl" --proof="proof.bin" -q 10
+```
+
+Making a call to preprocessor:
+
+```bash
+./build/bin/proof-producer/proof-producer-single-threaded --stage="preprocess" --circuit="circuit.crct" --assignment-table="assignment.tbl" --common-data="preprocessed_common_data.dat" --preprocessed-data="preprocessed.dat" --commitment-state-file="commitment_state.dat" --assignment-description-file="assignment-description.dat" -q 10
+```
+
+Making a call to prover:
+
+```bash
+./build/bin/proof-producer/proof-producer-single-threaded --stage="prove" --circuit="circuit.crct" --assignment-table="assignment.tbl" --common-data="preprocessed_common_data.dat" --preprocessed-data="preprocessed.dat" --commitment-state-file="commitment_state.dat" --proof="proof.bin" -q 10
+```
+
+Verify generated proof:
+```bash
+./build/bin/proof-producer/proof-producer-single-threaded --stage="verify" --circuit="circuit.crct" --common-data="preprocessed_common_data.dat" --proof="proof.bin" --assignment-description-file="assignment-description.dat" -q 10
+```

--- a/bin/proof-producer/include/nil/proof-generator/arg_parser.hpp
+++ b/bin/proof-producer/include/nil/proof-generator/arg_parser.hpp
@@ -34,14 +34,16 @@ namespace nil {
             typename tuple_to_variant<typename transform_tuple<HashTypes, to_type_identity>::type>::type;
 
         struct ProverOptions {
+            std::string stage = "all";
             boost::filesystem::path proof_file_path = "proof.bin";
             boost::filesystem::path json_file_path = "proof.json";
             boost::filesystem::path preprocessed_common_data_path = "preprocessed_common_data.dat";
+            boost::filesystem::path preprocessed_public_data_path = "preprocessed_data.dat";
+            boost::filesystem::path commitment_scheme_state_path = "commitment_scheme_state.dat";
             boost::filesystem::path circuit_file_path;
             boost::filesystem::path assignment_table_file_path;
+            boost::filesystem::path assignment_description_file_path;
             boost::log::trivial::severity_level log_level = boost::log::trivial::severity_level::info;
-            bool skip_verification = false;
-            bool verification_only = false;
             CurvesVariant elliptic_curve_type = type_identity<nil::crypto3::algebra::curves::pallas>{};
             HashesVariant hash_type = type_identity<nil::crypto3::hashes::keccak_1600<256>>{};
 

--- a/bin/proof-producer/include/nil/proof-generator/prover.hpp
+++ b/bin/proof-producer/include/nil/proof-generator/prover.hpp
@@ -26,14 +26,21 @@
 
 #include <boost/log/trivial.hpp>
 
+#include <nil/marshalling/endianness.hpp>
+#include <nil/marshalling/field_type.hpp>
+#include <nil/marshalling/status_type.hpp>
+
 #include <nil/crypto3/algebra/fields/arithmetic_params/pallas.hpp>
 #include <nil/crypto3/marshalling/zk/types/commitments/eval_storage.hpp>
 #include <nil/crypto3/marshalling/zk/types/commitments/lpc.hpp>
 #include <nil/crypto3/marshalling/zk/types/placeholder/common_data.hpp>
+#include <nil/crypto3/marshalling/zk/types/placeholder/preprocessed_public_data.hpp>
 #include <nil/crypto3/marshalling/zk/types/placeholder/proof.hpp>
 #include <nil/crypto3/marshalling/zk/types/plonk/assignment_table.hpp>
 #include <nil/crypto3/marshalling/zk/types/plonk/constraint_system.hpp>
+
 #include <nil/crypto3/math/algorithms/calculate_domain_set.hpp>
+
 #include <nil/crypto3/zk/snark/arithmetization/plonk/constraint_system.hpp>
 #include <nil/crypto3/zk/snark/arithmetization/plonk/params.hpp>
 #include <nil/crypto3/zk/snark/systems/plonk/placeholder/detail/placeholder_policy.hpp>
@@ -45,9 +52,8 @@
 #include <nil/crypto3/zk/snark/systems/plonk/placeholder/verifier.hpp>
 
 #include <nil/blueprint/transpiler/recursive_verifier_generator.hpp>
-#include <nil/marshalling/endianness.hpp>
-#include <nil/marshalling/field_type.hpp>
-#include <nil/marshalling/status_type.hpp>
+
+
 #include <nil/proof-generator/arithmetization_params.hpp>
 #include <nil/proof-generator/file_operations.hpp>
 
@@ -68,7 +74,7 @@ namespace nil {
                 auto read_iter = v->begin();
                 auto status = marshalled_data.read(read_iter, v->size());
                 if (status != nil::marshalling::status_type::success) {
-                    BOOST_LOG_TRIVIAL(error) << "Marshalled structure decoding failed";
+                    BOOST_LOG_TRIVIAL(error) << "When reading a Marshalled structure from file " << path << ", decoding step failed";
                     return std::nullopt;
                 }
                 return marshalled_data;
@@ -92,68 +98,80 @@ namespace nil {
                 return hex ? write_vector_to_hex_file(v, path.c_str()) : write_vector_to_file(v, path.c_str());
             }
 
-            std::vector<std::size_t> generate_random_step_list(const std::size_t r, const int max_step) {
-                using Distribution = std::uniform_int_distribution<int>;
-                static std::random_device random_engine;
+            enum class ProverStage {
+                ALL = 0,
+                PREPROCESS = 1,
+                PROVE = 2,
+                VERIFY = 3
+            };
 
-                std::vector<std::size_t> step_list;
-                std::size_t steps_sum = 0;
-                while (steps_sum != r) {
-                    if (r - steps_sum <= max_step) {
-                        while (r - steps_sum != 1) {
-                            step_list.emplace_back(r - steps_sum - 1);
-                            steps_sum += step_list.back();
-                        }
-                        step_list.emplace_back(1);
-                        steps_sum += step_list.back();
-                    } else {
-                        step_list.emplace_back(Distribution(1, max_step)(random_engine));
-                        steps_sum += step_list.back();
-                    }
+            ProverStage prover_stage_from_string(const std::string& stage) {
+                static std::unordered_map<std::string, ProverStage> stage_map = {
+                    {"all", ProverStage::ALL},
+                    {"preprocess", ProverStage::PREPROCESS},
+                    {"prove", ProverStage::PROVE},
+                    {"verify", ProverStage::VERIFY}
+                };
+                auto it = stage_map.find(stage);
+                if (it == stage_map.end()) {
+                    throw std::invalid_argument("Invalid stage: " + stage);
                 }
-                return step_list;
+                return it->second;
             }
+
         } // namespace detail
+
 
         template<typename CurveType, typename HashType>
         class Prover {
         public:
+            using BlueprintField = typename CurveType::base_field_type;
+            using LpcParams = nil::crypto3::zk::commitments::list_polynomial_commitment_params<HashType, HashType, 2>;
+            using Lpc = nil::crypto3::zk::commitments::list_polynomial_commitment<BlueprintField, LpcParams>;
+            using LpcScheme = typename nil::crypto3::zk::commitments::lpc_commitment_scheme<Lpc>;
+            using CircuitParams = nil::crypto3::zk::snark::placeholder_circuit_params<BlueprintField>;
+            using PlaceholderParams = nil::crypto3::zk::snark::placeholder_params<CircuitParams, LpcScheme>;
+            using Proof = nil::crypto3::zk::snark::placeholder_proof<BlueprintField, PlaceholderParams>;
+            using PublicPreprocessedData = typename nil::crypto3::zk::snark::
+                placeholder_public_preprocessor<BlueprintField, PlaceholderParams>::preprocessed_data_type;
+            using CommonData = typename PublicPreprocessedData::common_data_type;
+            using PrivatePreprocessedData = typename nil::crypto3::zk::snark::
+                placeholder_private_preprocessor<BlueprintField, PlaceholderParams>::preprocessed_data_type;
+            using ConstraintSystem = nil::crypto3::zk::snark::plonk_constraint_system<BlueprintField>;
+            using TableDescription = nil::crypto3::zk::snark::plonk_table_description<BlueprintField>;
+            using Endianness = nil::marshalling::option::big_endian;
+            using FriParams = typename Lpc::fri_type::params_type;
+            using Column = nil::crypto3::zk::snark::plonk_column<BlueprintField>;
+            using AssignmentTable = nil::crypto3::zk::snark::plonk_table<BlueprintField, Column>;
+            using TTypeBase = nil::marshalling::field_type<Endianness>;
+
             Prover(
-                boost::filesystem::path circuit_file_name,
-                boost::filesystem::path preprocessed_common_data_file_name,
-                boost::filesystem::path assignment_table_file_name,
-                boost::filesystem::path proof_file,
-                boost::filesystem::path json_file,
                 std::size_t lambda,
                 std::size_t expand_factor,
                 std::size_t max_q_chunks,
                 std::size_t grind
             )
-                : circuit_file_(circuit_file_name)
-                , preprocessed_common_data_file_(preprocessed_common_data_file_name)
-                , assignment_table_file_(assignment_table_file_name)
-                , proof_file_(proof_file)
-                , json_file_(json_file)
-                , lambda_(lambda)
+                : lambda_(lambda)
                 , expand_factor_(expand_factor)
                 , max_quotient_chunks_(max_q_chunks)
                 , grind_(grind) {
             }
 
-            bool generate_to_file(bool skip_verification) {
+            // The caller must call the preprocessor or load the preprocessed data before calling this function.
+            bool generate_to_file(
+                    boost::filesystem::path proof_file_,
+                    boost::filesystem::path json_file_,
+                    bool skip_verification) {
                 if (!nil::proof_generator::can_write_to_file(proof_file_.string())) {
                     BOOST_LOG_TRIVIAL(error) << "Can't write to file " << proof_file_;
                     return false;
                 }
-
-                prepare_for_operation();
 
                 BOOST_ASSERT(public_preprocessed_data_);
                 BOOST_ASSERT(private_preprocessed_data_);
                 BOOST_ASSERT(table_description_);
                 BOOST_ASSERT(constraint_system_);
                 BOOST_ASSERT(lpc_scheme_);
-                BOOST_ASSERT(fri_params_);
 
                 BOOST_LOG_TRIVIAL(info) << "Generating proof...";
                 Proof proof = nil::crypto3::zk::snark::placeholder_prover<BlueprintField, PlaceholderParams>::process(
@@ -175,14 +193,16 @@ namespace nil {
 
                 BOOST_LOG_TRIVIAL(info) << "Writing proof to " << proof_file_;
                 auto filled_placeholder_proof =
-                    nil::crypto3::marshalling::types::fill_placeholder_proof<Endianness, Proof>(proof, *fri_params_);
+                    nil::crypto3::marshalling::types::fill_placeholder_proof<Endianness, Proof>(proof, lpc_scheme_->get_fri_params());
                 bool res = nil::proof_generator::detail::encode_marshalling_to_file(
                     proof_file_,
                     filled_placeholder_proof,
                     true
                 );
                 if (res) {
-                    BOOST_LOG_TRIVIAL(info) << "Proof written";
+                    BOOST_LOG_TRIVIAL(info) << "Proof written.";
+                } else {
+                    BOOST_LOG_TRIVIAL(error) << "Failed to write proof to file.";
                 }
 
                 BOOST_LOG_TRIVIAL(info) << "Writing json proof to " << json_file_;
@@ -204,67 +224,140 @@ namespace nil {
                 return res;
             }
 
-            bool verify_from_file() {
-                prepare_for_operation();
+            bool verify_from_file(boost::filesystem::path proof_file_) {
+                create_lpc_scheme();
+
                 using ProofMarshalling = nil::crypto3::marshalling::types::
                     placeholder_proof<nil::marshalling::field_type<Endianness>, Proof>;
+
                 BOOST_LOG_TRIVIAL(info) << "Reading proof from file";
                 auto marshalled_proof = detail::decode_marshalling_from_file<ProofMarshalling>(proof_file_, true);
                 if (!marshalled_proof) {
                     return false;
                 }
-                bool res =
-                    verify(nil::crypto3::marshalling::types::make_placeholder_proof<Endianness, Proof>(*marshalled_proof
-                    ));
+                bool res = verify(nil::crypto3::marshalling::types::make_placeholder_proof<Endianness, Proof>(
+                    *marshalled_proof));
                 if (res) {
-                    BOOST_LOG_TRIVIAL(info) << "Proof verified";
+                    BOOST_LOG_TRIVIAL(info) << "Proof verification passed.";
                 }
                 return res;
             }
 
-            bool save_preprocessed_common_data_to_file() {
-                BOOST_LOG_TRIVIAL(info) << "Writing preprocessed common data to file...";
-                using Endianness = nil::marshalling::option::big_endian;
-                using TTypeBase = nil::marshalling::field_type<Endianness>;
-                using CommonData = typename PublicPreprocessedData::preprocessed_data_type::common_data_type;
+            bool save_preprocessed_common_data_to_file(boost::filesystem::path preprocessed_common_data_file) {
+                BOOST_LOG_TRIVIAL(info) << "Writing preprocessed common data to " << preprocessed_common_data_file << std::endl;
                 auto marshalled_common_data =
                     nil::crypto3::marshalling::types::fill_placeholder_common_data<Endianness, CommonData>(
                         public_preprocessed_data_->common_data
                     );
                 bool res = nil::proof_generator::detail::encode_marshalling_to_file(
-                    preprocessed_common_data_file_,
+                    preprocessed_common_data_file,
                     marshalled_common_data
                 );
                 if (res) {
-                    BOOST_LOG_TRIVIAL(info) << "Preprocessed common data written";
+                    BOOST_LOG_TRIVIAL(info) << "Preprocessed common data written.";
                 }
                 return res;
             }
 
-        private:
-            using BlueprintField = typename CurveType::base_field_type;
-            using LpcParams = nil::crypto3::zk::commitments::list_polynomial_commitment_params<HashType, HashType, 2>;
-            using Lpc = nil::crypto3::zk::commitments::list_polynomial_commitment<BlueprintField, LpcParams>;
-            using LpcScheme = typename nil::crypto3::zk::commitments::lpc_commitment_scheme<Lpc>;
-            using CircuitParams = nil::crypto3::zk::snark::placeholder_circuit_params<BlueprintField>;
-            using PlaceholderParams = nil::crypto3::zk::snark::placeholder_params<CircuitParams, LpcScheme>;
-            using Proof = nil::crypto3::zk::snark::placeholder_proof<BlueprintField, PlaceholderParams>;
-            using PublicPreprocessedData = typename nil::crypto3::zk::snark::
-                placeholder_public_preprocessor<BlueprintField, PlaceholderParams>::preprocessed_data_type;
-            using PrivatePreprocessedData = typename nil::crypto3::zk::snark::
-                placeholder_private_preprocessor<BlueprintField, PlaceholderParams>::preprocessed_data_type;
-            using ConstraintSystem = nil::crypto3::zk::snark::plonk_constraint_system<BlueprintField>;
-            using TableDescription = nil::crypto3::zk::snark::plonk_table_description<BlueprintField>;
-            using Endianness = nil::marshalling::option::big_endian;
-            using FriParams = typename Lpc::fri_type::params_type;
-            using Column = nil::crypto3::zk::snark::plonk_column<BlueprintField>;
-            using AssignmentTable = nil::crypto3::zk::snark::plonk_table<BlueprintField, Column>;
+            bool read_preprocessed_common_data_from_file(boost::filesystem::path preprocessed_common_data_file) {
+                BOOST_LOG_TRIVIAL(info) << "Read preprocessed common data from " << preprocessed_common_data_file << std::endl;
+
+                using CommonDataMarshalling = nil::crypto3::marshalling::types::placeholder_common_data<TTypeBase, CommonData>;
+
+                auto marshalled_value = detail::decode_marshalling_from_file<CommonDataMarshalling>(
+                    preprocessed_common_data_file);
+
+                if (!marshalled_value) {
+                    return false;
+                }
+                common_data_.emplace(nil::crypto3::marshalling::types::make_placeholder_common_data<Endianness, CommonData>(
+                    *marshalled_value));
+
+                return true;
+            }
+
+            // This includes not only the common data, but also merkle trees, polynomials, etc, everything that a 
+            // public preprocessor generates.
+            bool save_public_preprocessed_data_to_file(boost::filesystem::path preprocessed_data_file) {
+                using namespace nil::crypto3::marshalling::types;
+
+                BOOST_LOG_TRIVIAL(info) << "Writing all preprocessed public data to " << 
+                    preprocessed_data_file << std::endl;
+                using PreprocessedPublicDataType = typename PublicPreprocessedData::preprocessed_data_type;
+
+                auto marshalled_preprocessed_public_data =
+                    fill_placeholder_preprocessed_public_data<Endianness, PreprocessedPublicDataType>(
+                        *public_preprocessed_data_
+                    );
+                bool res = nil::proof_generator::detail::encode_marshalling_to_file(
+                    preprocessed_data_file,
+                    marshalled_preprocessed_public_data
+                );
+                if (res) {
+                    BOOST_LOG_TRIVIAL(info) << "Preprocessed public data written.";
+                }
+                return res;
+            }
+
+            bool read_public_preprocessed_data_from_file(boost::filesystem::path preprocessed_data_file) {
+                BOOST_LOG_TRIVIAL(info) << "Read preprocessed data from " << preprocessed_data_file << std::endl;
+
+                using namespace nil::crypto3::marshalling::types;
+
+                using PreprocessedPublicDataType = typename PublicPreprocessedData::preprocessed_data_type;
+                using PublicPreprocessedDataMarshalling =
+                    placeholder_preprocessed_public_data<TTypeBase, PreprocessedPublicDataType>;
+
+                auto marshalled_value = detail::decode_marshalling_from_file<PublicPreprocessedDataMarshalling>(
+                    preprocessed_data_file);
+                if (!marshalled_value) {
+                    return false;
+                }
+                public_preprocessed_data_.emplace(
+                    make_placeholder_preprocessed_public_data<Endianness, PreprocessedPublicDataType>(*marshalled_value)
+                );
+                return true;
+            }
+
+            bool save_commitment_state_to_file(boost::filesystem::path commitment_scheme_state_file) {
+                using namespace nil::crypto3::marshalling::types;
+
+                BOOST_LOG_TRIVIAL(info) << "Writing commitment_state to " << 
+                    commitment_scheme_state_file << std::endl;
+
+                auto marshalled_lpc_state = fill_commitment_scheme<Endianness, LpcScheme>(
+                    *lpc_scheme_);
+                bool res = nil::proof_generator::detail::encode_marshalling_to_file(
+                    commitment_scheme_state_file,
+                    marshalled_lpc_state
+                );
+                if (res) {
+                    BOOST_LOG_TRIVIAL(info) << "Commitment scheme written.";
+                }
+                return res;
+            }
+
+            bool read_commitment_scheme_from_file(boost::filesystem::path commitment_scheme_state_file) {
+                BOOST_LOG_TRIVIAL(info) << "Read commitment scheme from " << commitment_scheme_state_file << std::endl;
+
+                using namespace nil::crypto3::marshalling::types;
+
+                using CommitmentStateMarshalling = typename commitment_scheme_state<TTypeBase, LpcScheme>::type;
+
+                auto marshalled_value = detail::decode_marshalling_from_file<CommitmentStateMarshalling>(
+                    commitment_scheme_state_file);
+                if (!marshalled_value) {
+                    return false;
+                }
+                lpc_scheme_.emplace(make_commitment_scheme<Endianness, LpcScheme>(*marshalled_value));
+                return true;
+            }
 
             bool verify(const Proof& proof) const {
                 BOOST_LOG_TRIVIAL(info) << "Verifying proof...";
                 bool verification_result =
                     nil::crypto3::zk::snark::placeholder_verifier<BlueprintField, PlaceholderParams>::process(
-                        public_preprocessed_data_->common_data,
+                        public_preprocessed_data_.has_value() ? public_preprocessed_data_->common_data : *common_data_,
                         proof,
                         *table_description_,
                         *constraint_system_,
@@ -280,23 +373,26 @@ namespace nil {
                 return verification_result;
             }
 
-            bool prepare_for_operation() {
-                using BlueprintField = typename CurveType::base_field_type;
-                using TTypeBase = nil::marshalling::field_type<Endianness>;
+            bool read_circuit(const boost::filesystem::path& circuit_file_) {
+                BOOST_LOG_TRIVIAL(info) << "Read circuit from " << circuit_file_ << std::endl;
+
                 using ConstraintMarshalling =
                     nil::crypto3::marshalling::types::plonk_constraint_system<TTypeBase, ConstraintSystem>;
 
-                {
-                    auto marshalled_value = detail::decode_marshalling_from_file<ConstraintMarshalling>(circuit_file_);
-                    if (!marshalled_value) {
-                        return false;
-                    }
-                    constraint_system_.emplace(
-                        nil::crypto3::marshalling::types::make_plonk_constraint_system<Endianness, ConstraintSystem>(
-                            *marshalled_value
-                        )
-                    );
+                auto marshalled_value = detail::decode_marshalling_from_file<ConstraintMarshalling>(circuit_file_);
+                if (!marshalled_value) {
+                    return false;
                 }
+                constraint_system_.emplace(
+                    nil::crypto3::marshalling::types::make_plonk_constraint_system<Endianness, ConstraintSystem>(
+                        *marshalled_value
+                    )
+                );
+                return true;
+            }
+
+            bool read_assignment_table(const boost::filesystem::path& assignment_table_file_) {
+                BOOST_LOG_TRIVIAL(info) << "Read assignment table from " << assignment_table_file_ << std::endl;
 
                 using TableValueMarshalling =
                     nil::crypto3::marshalling::types::plonk_assignment_table<TTypeBase, AssignmentTable>;
@@ -309,53 +405,103 @@ namespace nil {
                     nil::crypto3::marshalling::types::make_assignment_table<Endianness, AssignmentTable>(
                         *marshalled_table
                     );
-
-                public_inputs_.emplace(assignment_table.public_inputs());
                 table_description_.emplace(table_description);
+                assignment_table_.emplace(std::move(assignment_table));
+                return true;
+            }
 
-                // Lambdas and grinding bits should be passed threw preprocessor directives
+            bool save_assignment_description(const boost::filesystem::path& assignment_description_file) {
+                BOOST_LOG_TRIVIAL(info) << "Writing assignment description to " << assignment_description_file << std::endl;
+
+                auto marshalled_assignment_description =
+                    nil::crypto3::marshalling::types::fill_assignment_table_description<Endianness, BlueprintField>(
+                        *table_description_     
+                    );
+                bool res = nil::proof_generator::detail::encode_marshalling_to_file(
+                    assignment_description_file,
+                    marshalled_assignment_description
+                );
+                if (res) {
+                    BOOST_LOG_TRIVIAL(info) << "Assignment description written.";
+                }
+                return res;
+            }
+
+            bool read_assignment_description(const boost::filesystem::path& assignment_description_file_) {
+                BOOST_LOG_TRIVIAL(info) << "Read assignment description from " << assignment_description_file_ << std::endl;
+
+                using TableDescriptionMarshalling =
+                    nil::crypto3::marshalling::types::plonk_assignment_table_description<TTypeBase>;
+                auto marshalled_description =
+                    detail::decode_marshalling_from_file<TableDescriptionMarshalling>(assignment_description_file_);
+                if (!marshalled_description) {
+                    return false;
+                }
+                auto table_description =
+                    nil::crypto3::marshalling::types::make_assignment_table_description<Endianness, BlueprintField>(
+                        *marshalled_description
+                    );
+                table_description_.emplace(table_description);
+                return true;
+            }
+
+            void create_lpc_scheme() {
+                // Lambdas and grinding bits should be passed through preprocessor directives
                 std::size_t table_rows_log = std::ceil(std::log2(table_description_->rows_amount));
 
-                fri_params_.emplace(FriParams(1, table_rows_log, lambda_, expand_factor_));
-                lpc_scheme_.emplace(*fri_params_);
+                lpc_scheme_.emplace(FriParams(1, table_rows_log, lambda_, expand_factor_));
+            }
+
+            bool preprocess_public_data() {
+                public_inputs_.emplace(assignment_table_->public_inputs());
+
+                create_lpc_scheme();
 
                 BOOST_LOG_TRIVIAL(info) << "Preprocessing public data";
                 public_preprocessed_data_.emplace(
                     nil::crypto3::zk::snark::placeholder_public_preprocessor<BlueprintField, PlaceholderParams>::
                         process(
                             *constraint_system_,
-                            assignment_table.move_public_table(),
+                            assignment_table_->move_public_table(),
                             *table_description_,
                             *lpc_scheme_,
                             max_quotient_chunks_
                         )
                 );
+                return true;
+            }
+
+            bool preprocess_private_data() {
 
                 BOOST_LOG_TRIVIAL(info) << "Preprocessing private data";
                 private_preprocessed_data_.emplace(
                     nil::crypto3::zk::snark::placeholder_private_preprocessor<BlueprintField, PlaceholderParams>::
-                        process(*constraint_system_, assignment_table.move_private_table(), *table_description_)
+                        process(*constraint_system_, assignment_table_->move_private_table(), *table_description_)
                 );
+
+                // This is the last stage of preprocessor, and the assignment table is not used after this function call.
+                assignment_table_.reset();
+
                 return true;
             }
 
-            const boost::filesystem::path circuit_file_;
-            const boost::filesystem::path preprocessed_common_data_file_;
-            const boost::filesystem::path assignment_table_file_;
-            const boost::filesystem::path proof_file_;
-            const boost::filesystem::path json_file_;
+        private:
             const std::size_t expand_factor_;
             const std::size_t max_quotient_chunks_;
             const std::size_t lambda_;
             const std::size_t grind_;
 
-            // All set on prepare_for_operation()
             std::optional<PublicPreprocessedData> public_preprocessed_data_;
+
+            // TODO: This is used in verifier, since it does not need the whole preprocessed data.
+            // It makes sence to separate prover class from verifier later.
+            std::optional<CommonData> common_data_;
+
             std::optional<PrivatePreprocessedData> private_preprocessed_data_;
             std::optional<typename AssignmentTable::public_input_container_type> public_inputs_;
             std::optional<TableDescription> table_description_;
             std::optional<ConstraintSystem> constraint_system_;
-            std::optional<FriParams> fri_params_;
+            std::optional<AssignmentTable> assignment_table_;
             std::optional<LpcScheme> lpc_scheme_;
         };
 

--- a/bin/proof-producer/src/arg_parser.cpp
+++ b/bin/proof-producer/src/arg_parser.cpp
@@ -72,20 +72,24 @@ namespace nil {
             );
             // clang-format off
             auto options_appender = config.add_options()
-                ("proof,p", make_defaulted_option(prover_options.proof_file_path), "Output proof file")
+                ("stage", make_defaulted_option(prover_options.stage),
+                 "Stage of the prover to run, one of (all, preprocess, prove, verify). Defaults to 'all'.")
+                ("proof,p", make_defaulted_option(prover_options.proof_file_path), "Proof file")
                 ("json,j", make_defaulted_option(prover_options.json_file_path), "JSON proof file")
-                ("common-data,d", make_defaulted_option(prover_options.preprocessed_common_data_path), "Output preprocessed common data file")
-                ("circuit", po::value(&prover_options.circuit_file_path)->required(), "Circuit input file")
-                ("assignment-table,t", po::value(&prover_options.assignment_table_file_path)->required(), "Assignment table input file")
+                ("common-data", make_defaulted_option(prover_options.preprocessed_common_data_path), "Preprocessed common data file")
+                ("preprocessed-data", make_defaulted_option(prover_options.preprocessed_public_data_path), "Preprocessed public data file")
+                ("commitment-state-file", make_defaulted_option(prover_options.commitment_scheme_state_path), "Commitment state data file")
+                ("circuit", po::value(&prover_options.circuit_file_path), "Circuit input file")
+                ("assignment-table,t", po::value(&prover_options.assignment_table_file_path), "Assignment table input file")
+                ("assignment-description-file", po::value(&prover_options.assignment_description_file_path), "Assignment description file")
                 ("log-level,l", make_defaulted_option(prover_options.log_level), "Log level (trace, debug, info, warning, error, fatal)")
                 ("elliptic-curve-type,e", make_defaulted_option(prover_options.elliptic_curve_type), "Elliptic curve type (pallas)")
                 ("hash-type", make_defaulted_option(prover_options.hash_type), "Hash type (keccak, poseidon, sha256)")
                 ("lambda-param", make_defaulted_option(prover_options.lambda), "Lambda param (9)")
                 ("grind-param", make_defaulted_option(prover_options.grind), "Grind param (69)")
                 ("expand-factor,x", make_defaulted_option(prover_options.expand_factor), "Expand factor")
-                ("max-quotient-chunks,q", make_defaulted_option(prover_options.max_quotient_chunks), "Maximum quotient polynomial parts amount")
-                ("skip-verification", po::bool_switch(&prover_options.skip_verification), "Skip generated proof verifying step")
-                ("verification-only", po::bool_switch(&prover_options.verification_only), "Read proof for verification instead of writing to it");
+                ("max-quotient-chunks,q", make_defaulted_option(prover_options.max_quotient_chunks), "Maximum quotient polynomial parts amount");
+
             // clang-format on
             po::options_description cmdline_options("nil; Proof Producer");
             cmdline_options.add(generic).add(config);

--- a/flake.lock
+++ b/flake.lock
@@ -9,11 +9,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721325480,
-        "narHash": "sha256-ZyPvRjfeLVswifsbmoUm2LIcrqIaXR4wQmA0XdpEv6g=",
+        "lastModified": 1726125910,
+        "narHash": "sha256-AgwapAsC6l4Guf8XFpS8quOm6jd9Mo2w4btaaXAkYwU=",
         "ref": "refs/heads/master",
-        "rev": "45074e0549d46b8fa67a844111c52277134a0272",
-        "revCount": 9160,
+        "rev": "246955ad06f9f1bf4bbb75ed2870cca5df331fa7",
+        "revCount": 10454,
         "type": "git",
         "url": "https://github.com/NilFoundation/crypto3"
       },
@@ -58,6 +58,24 @@
         "type": "github"
       }
     },
+    "flake-utils_3": {
+      "inputs": {
+        "systems": "systems_3"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "nix-3rdparty": {
       "inputs": {
         "flake-utils": [
@@ -75,6 +93,31 @@
         "owner": "NilFoundation",
         "repo": "nix-3rdparty",
         "rev": "a2e45429aa25a4a6e8e362ef17df6f197312f224",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NilFoundation",
+        "repo": "nix-3rdparty",
+        "type": "github"
+      }
+    },
+    "nix-3rdparty_2": {
+      "inputs": {
+        "flake-utils": [
+          "parallel-crypto3",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "parallel-crypto3",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1721822436,
+        "narHash": "sha256-AQidmv80fA72FFHgyjCq9Psc04w9aaHedJpoVgnLb6M=",
+        "owner": "NilFoundation",
+        "repo": "nix-3rdparty",
+        "rev": "d14a2a3c4b9498b297400b225fc09570bfe0a9a1",
         "type": "github"
       },
       "original": {
@@ -104,16 +147,18 @@
         "crypto3": [
           "crypto3"
         ],
+        "flake-utils": "flake-utils_3",
+        "nix-3rdparty": "nix-3rdparty_2",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1721378514,
-        "narHash": "sha256-3XRkqdZRe26YDBPWFZmpVqyFQeqPmDczx5AaaY3FRTQ=",
+        "lastModified": 1726133783,
+        "narHash": "sha256-yCn5iYTgREHxHx4qajl7E/1BOEu6ToKAxeJz2XNnnSk=",
         "ref": "refs/heads/master",
-        "rev": "404077b3f00f8c901cfad95c8c6c116eb172b8e2",
-        "revCount": 1460,
+        "rev": "07f03019fd0467716c419692a309bca0e8b9718a",
+        "revCount": 1466,
         "submodules": true,
         "type": "git",
         "url": "https://github.com/NilFoundation/parallel-crypto3"
@@ -148,6 +193,21 @@
       }
     },
     "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_3": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",


### PR DESCRIPTION
We need to separate the preprocessor from prover in proof-producer. Currently both steps are ran with a single command, but in "real world" we would run the preprocessor only once per circuit.